### PR TITLE
Fix crash if user take and delete a picture

### DIFF
--- a/Sources/MosaiqueAssetsPicker/ViewControllers/AssetDetailViewController.swift
+++ b/Sources/MosaiqueAssetsPicker/ViewControllers/AssetDetailViewController.swift
@@ -264,7 +264,7 @@ extension AssetDetailViewController: AssetDetailViewModelDelegate {
                 if let removed = changes.removedIndexes, removed.count > 0 {
                     collectionView.deleteItems(at: removed.map { IndexPath(item: $0, section:0) })
                 }
-                if let inserted = changes.insertedIndexes, inserted.count > 0 {
+                if let inserted = changes.insertedIndexes?.filter({ !(changes.removedIndexes?.contains($0) ?? true) }), inserted.count > 0 {
                     collectionView.insertItems(at: inserted.map { IndexPath(item: $0, section:0) })
                 }
                 if let changed = changes.changedIndexes, changed.count > 0 {


### PR DESCRIPTION
To reproduce:


- Present a detail view
- take a picture
- remove it 
- open app

=> crash 

I used a snippet of code from Apple documentation to implement this function. Since then, it looks like apple completely changed it: https://developer.apple.com/documentation/photokit/phfetchresultchangedetails

We might want to investigate deeper while this change was warranted (apart from the obvious crash..)