### PR TITLE
call didCancel instead of didPickImages for 0 images

### DIFF
--- a/Sources/Demo/Demo1Default/DefaultDemoViewController.swift
+++ b/Sources/Demo/Demo1Default/DefaultDemoViewController.swift
@@ -37,7 +37,7 @@ extension DemoDefaultViewController: MosaiqueAssetPickerDelegate {
         print("main didPickImages = \(images)")
     }
     
-    func photoPickerDidCancel(_ controller: MosaiqueAssetPickerViewController) {
+    func photoPickerDidCancel(_ controller: UIViewController) {
         print("photoPickerDidCancel")
         self.dismiss(animated: true, completion: nil)
     }

--- a/Sources/Demo/Demo2CustomClass/CustomCellDemoViewController.swift
+++ b/Sources/Demo/Demo2CustomClass/CustomCellDemoViewController.swift
@@ -45,7 +45,7 @@ extension Demo2ViewController: MosaiqueAssetPickerDelegate {
         print("main didPickImages = \(images)")
     }
     
-    func photoPickerDidCancel(_ pickerController: MosaiqueAssetPickerViewController) {
+    func photoPickerDidCancel(_ controller: UIViewController) {
         print("photoPickerDidCancel")
         self.dismiss(animated: true, completion: nil)
     }

--- a/Sources/Demo/Demo3CustomNib/Demo3ViewController.swift
+++ b/Sources/Demo/Demo3CustomNib/Demo3ViewController.swift
@@ -44,7 +44,7 @@ extension Demo3ViewController: MosaiqueAssetPickerDelegate {
         self.dismiss(animated: true, completion: nil)
     }
     
-    func photoPickerDidCancel(_ pickerController: MosaiqueAssetPickerViewController) {
+    func photoPickerDidCancel(_ controller: UIViewController) {
         print("photoPickerDidCancel")
         self.dismiss(animated: true, completion: nil)
     }

--- a/Sources/Demo/Demo4CustomHeader/Demo4ViewController.swift
+++ b/Sources/Demo/Demo4CustomHeader/Demo4ViewController.swift
@@ -42,7 +42,7 @@ extension Demo4ViewController: MosaiqueAssetPickerDelegate {
         print("main didPickImages = \(images)")
     }
     
-    func photoPickerDidCancel(_ pickerController: MosaiqueAssetPickerViewController) {
+    func photoPickerDidCancel(_ controller: UIViewController) {
         print("photoPickerDidCancel")
         self.dismiss(animated: true, completion: nil)
     }

--- a/Sources/Demo/Demo5MultipleAssetSelection/Demo5MultipleAssetSelection.swift
+++ b/Sources/Demo/Demo5MultipleAssetSelection/Demo5MultipleAssetSelection.swift
@@ -36,7 +36,7 @@ extension Demo5MultipleAssetSelection: MosaiqueAssetPickerDelegate {
         print("main didPickImages = \(images)")
     }
 
-    func photoPickerDidCancel(_ pickerController: MosaiqueAssetPickerViewController) {
+    func photoPickerDidCancel(_ controller: UIViewController) {
         print("photoPickerDidCancel")
         self.dismiss(animated: true, completion: nil)
     }

--- a/Sources/Demo/Demo6iOS14/Demo6iOS14.swift
+++ b/Sources/Demo/Demo6iOS14/Demo6iOS14.swift
@@ -33,7 +33,7 @@ extension Demo6iOS14: MosaiqueAssetPickerDelegate {
         print("main didPickImages = \(images)")
     }
 
-    func photoPickerDidCancel(_ pickerController: MosaiqueAssetPickerViewController) {
+    func photoPickerDidCancel(_ controller: UIViewController) {
         print("photoPickerDidCancel")
         self.dismiss(animated: true, completion: nil)
     }

--- a/Sources/MosaiqueAssetsPicker/Utils/MosaiqueAssetPickerPresenter.swift
+++ b/Sources/MosaiqueAssetsPicker/Utils/MosaiqueAssetPickerPresenter.swift
@@ -65,8 +65,12 @@ public final class MosaiqueAssetPickerPresenter: PHPickerViewControllerDelegate 
                 dispatchGroup.leave()
             }
         }
-         dispatchGroup.notify(queue: DispatchQueue.main) { [weak self] in
-            self?.delegate?.photoPicker(picker, didPickImages: images)
+        dispatchGroup.notify(queue: DispatchQueue.main) { [weak self] in
+            if images.isEmpty {
+                self?.delegate?.photoPickerDidCancel(picker)
+            } else {
+                self?.delegate?.photoPicker(picker, didPickImages: images)
+            }
         }
    }
 }

--- a/Sources/MosaiqueAssetsPicker/ViewControllers/MosaiqueAssetPickerViewController.swift
+++ b/Sources/MosaiqueAssetsPicker/ViewControllers/MosaiqueAssetPickerViewController.swift
@@ -17,7 +17,7 @@ public protocol MosaiqueAssetPickerDelegate: class {
     /// - Wait for the images to be ready (will be provided with by the `didPickImages`
     func photoPicker(_ controller: UIViewController, didPickAssets assets: [AssetFuture])
 
-    func photoPickerDidCancel(_ pickerController: UIViewController)
+    func photoPickerDidCancel(_ controller: UIViewController)
 }
 
 public final class MosaiqueAssetPickerViewController : UINavigationController {

--- a/Sources/MosaiqueAssetsPicker/ViewControllers/MosaiqueAssetPickerViewController.swift
+++ b/Sources/MosaiqueAssetsPicker/ViewControllers/MosaiqueAssetPickerViewController.swift
@@ -17,7 +17,7 @@ public protocol MosaiqueAssetPickerDelegate: class {
     /// - Wait for the images to be ready (will be provided with by the `didPickImages`
     func photoPicker(_ controller: UIViewController, didPickAssets assets: [AssetFuture])
 
-    func photoPickerDidCancel(_ pickerController: MosaiqueAssetPickerViewController)
+    func photoPickerDidCancel(_ pickerController: UIViewController)
 }
 
 public final class MosaiqueAssetPickerViewController : UINavigationController {


### PR DESCRIPTION
When I tap cancel on `PHPickerViewController` (used on iOS 14), `photoPicker(_, didPickImages:)` gets called with 0 images.
When I tap cancel on `MosaiqueAssetPickerViewController` (used on iOS 13), `photoPickerDidCancel(_)` gets called.
I think it should be same for `PHPickerViewController`, so I'd like to propose this PR.